### PR TITLE
Fix texture size too large error for high-resolution images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-depthflow-nodes"
 description = "Implementation of DepthFlow nodes for ComfyUI, adds a 2.5D parallax effect to images and videos. Compatible with Ryan's Flex system."
-version = "1.2.2"
+version = "1.2.3"
 license = {file = "LICENSE"}
 dependencies = [
     "depthflow==0.9.1",


### PR DESCRIPTION
## Summary
- Set `scene.config.upscaler.scale = 1` to prevent incorrect resolution doubling from the pypi depthflow package which wrongly defaults to 2
- Add validation to check image dimensions against OpenGL max texture size (16384) with a helpful error message before processing

## Problem
When users input images around 2000x2000 pixels to the Depthflow node, they encounter the error:
```
Texture size too large for this OpenGL context: (20000, 11160) > 16384
```

The root cause was identified by the shaderflow author: the pypi depthflow package incorrectly sets `upscaler.scale` to 2 due to inheritance issues, causing unintended resolution multiplication.

## Changes
1. **Disable upscaler scaling** (`src/depthflow.py:336-338`): Sets `scene.config.upscaler.scale = 1` after scene creation to prevent the incorrect default
2. **Add dimension validation** (`src/depthflow.py:418-425`): Validates input image dimensions against OpenGL's 16384 max texture size limit, providing a clear error message to users

## Test plan
- [ ] Test with a 2000x2000 image that previously caused the error
- [ ] Test with images close to but under 16384 pixels
- [ ] Test with images over 16384 pixels to verify helpful error message
- [ ] Verify normal depthflow animation still works correctly